### PR TITLE
Bugfix: fix compressUsingCDict by adding the compression level to CDict

### DIFF
--- a/Codec/Compression/Zstd/Base.hs
+++ b/Codec/Compression/Zstd/Base.hs
@@ -335,7 +335,7 @@ createCDict dict size level = do
   cd <- FFI.checkAlloc "createCDict" $
         FFI.createCDict dict (fromIntegral size) (fromIntegral level)
   fp <- newForeignPtr FFI.p_freeCDict cd
-  return (CD fp)
+  return (CD level fp)
 
 -- | Compress bytes from source buffer into destination buffer, using
 -- a pre-digested dictionary.  The destination buffer must be already
@@ -351,7 +351,7 @@ compressUsingCDict
     -> Int         -- ^ Size of source buffer.
     -> CDict       -- ^ Dictionary.
     -> IO (Either String Int)
-compressUsingCDict ctx dst dstSize src srcSize (CD fp) =
+compressUsingCDict ctx dst dstSize src srcSize (CD _ fp) =
   checkError . withForeignPtr fp $ \ dict ->
   FFI.compressUsingCDict ctx dst (fromIntegral dstSize)
     src (fromIntegral srcSize) dict

--- a/Codec/Compression/Zstd/Base/Types.hs
+++ b/Codec/Compression/Zstd/Base/Types.hs
@@ -22,7 +22,7 @@ import Foreign.ForeignPtr (ForeignPtr)
 import qualified Codec.Compression.Zstd.FFI.Types as FFI
 
 -- | A pre-digested compression dictionary.
-newtype CDict = CD (ForeignPtr FFI.CDict)
+data CDict = CD Int (ForeignPtr FFI.CDict)
 
 -- | A pre-digested decompression dictionary.
 newtype DDict = DD (ForeignPtr FFI.DDict)

--- a/Codec/Compression/Zstd/Efficient.hs
+++ b/Codec/Compression/Zstd/Efficient.hs
@@ -145,10 +145,10 @@ compressUsingCDict :: CCtx
                    -> ByteString
                    -- ^ Payload to compress.
                    -> IO ByteString
-compressUsingCDict (CCtx ctx) (CD fp) bs =
+compressUsingCDict (CCtx ctx) (CD l fp) bs =
   withForeignPtr fp $ \dict -> do
     let compressor dp dl sp sl _ = C.compressUsingCDict ctx dp dl sp sl dict
-    compressWith "compressUsingCDict" compressor 0 bs
+    compressWith "compressUsingCDict" compressor l bs
 
 -- | Create a pre-digested compression dictionary.
 createDDict :: Dict             -- ^ Dictionary.


### PR DESCRIPTION
Previously compressUsingCDict would always fail because the level was hardcoded to zero, which fails the check in `compressWith`.