### PR TITLE
Bump to zstd 1.4.5

### DIFF
--- a/zstd.cabal
+++ b/zstd.cabal
@@ -63,6 +63,9 @@ library
       zstd/lib/compress/fse_compress.c
       zstd/lib/compress/hist.c
       zstd/lib/compress/huf_compress.c
+      zstd/lib/compress/zstd_compress_literals.c
+      zstd/lib/compress/zstd_compress_sequences.c
+      zstd/lib/compress/zstd_compress_superblock.c
       zstd/lib/compress/zstd_compress.c
       zstd/lib/compress/zstd_double_fast.c
       zstd/lib/compress/zstd_fast.c


### PR DESCRIPTION
Updates the .cabal file and the submodule appropriately. 