### PR TITLE
feat: add FFI bindings for zstd's advanced API

### DIFF
--- a/Codec/Compression/Zstd/FFI.hs
+++ b/Codec/Compression/Zstd/FFI.hs
@@ -106,7 +106,26 @@ module Codec.Compression.Zstd.FFI
     , p_freeDDict
     , decompressUsingDDict
 
+    -- * Advanced API
+    , c_compress2
+    , c_compressStream2
+    , cCtxSetParameter
+    , cCtxReset
+
     -- * Low-level code
+    -- ** Parameter and directive constants
+    , zstd_c_compressionLevel
+    , zstd_c_nbWorkers
+    , zstd_c_jobSize
+    , zstd_c_overlapLog
+    , zstd_e_continue
+    , zstd_e_flush
+    , zstd_e_end
+    , zstd_reset_session_only
+    , zstd_reset_parameters
+    , zstd_reset_session_and_parameters
+
+    -- ** Helper functions
     , c_maxCLevel
     ) where
 
@@ -459,3 +478,71 @@ checkError act = do
   return $! if isError ret
             then Left (getErrorName ret)
             else Right ret
+
+-- | Compress bytes from source buffer into destination buffer using sticky
+-- parameters previously set on the 'CCtx' via 'cCtxSetParameter'.
+--
+-- Always starts a new frame; any previously-buffered partial frame state on
+-- the context is discarded.
+-- 
+-- Returns the number of bytes written into destination buffer, or an error
+-- code if it fails (which can be tested using 'isError').
+--
+-- /NOTE/: 'safe' because this can block when @ZSTD_c_nbWorkers >= 1@.
+foreign import ccall safe "ZSTD_compress2"
+    c_compress2 :: Ptr CCtx     -- ^ Compression context.
+                -> Ptr dst      -- ^ Destination buffer.
+                -> CSize        -- ^ Capacity of destination buffer.
+                -> Ptr src      -- ^ Source buffer.
+                -> CSize        -- ^ Size of source buffer.
+                -> IO CSize
+
+-- | Consume part or all of an input, returning either @0@ (indicating that all
+-- internally buffered data has been flushed and the current operation is
+-- complete) or the minimum number of bytes left to flush.
+-- 
+-- Returns the minimum number of bytes left to flush, @0@ (indicating that all
+-- internally buffered data and the current operation is complete), or an error
+-- code if it fails (which can be tested using 'isError').
+--
+-- The 'CInt' end-directive is one of 'zstd_e_continue' (corresponds to
+-- 'compressStream'), 'zstd_e_flush', or 'zstd_e_end' (corresponds to
+-- 'endStream').
+--
+-- /NOTE/: 'safe' because this can block when @ZSTD_c_nbWorkers >= 1@.
+foreign import ccall safe "ZSTD_compressStream2"
+    c_compressStream2 :: Ptr CCtx          -- ^ Compression context.
+                      -> Ptr (Buffer Out)  -- ^ Output buffer.
+                      -> Ptr (Buffer In)   -- ^ Input buffer.
+                      -> CInt              -- ^ ZSTD_EndDirective.
+                      -> IO CSize
+
+-- | Set a compression parameter on the context.
+--
+-- Parameters are sticky: they apply to every subsequent compression call made
+-- with the given 'CCtx' until reset via 'cCtxReset' with 'zstd_reset_parameters'
+-- or 'zstd_reset_session_and_parameters', or overwritten by another
+-- 'cCtxSetParameter' call.
+-- 
+-- Returns @0@ on success or an error code (which can be tested using 'isError').
+--
+-- /NOTE/: This behavior does __not__ apply to 'compressCCtx', which takes its
+-- compression level inline and does not honor sticky parameters.
+foreign import ccall unsafe "ZSTD_CCtx_setParameter"
+    cCtxSetParameter :: Ptr CCtx
+                     -> CInt   -- ^ ZSTD_cParameter (e.g. 'zstd_c_nbWorkers').
+                     -> CInt   -- ^ Parameter value.
+                     -> IO CSize
+
+-- | Reset the compression context; fails if the directive is invalid for the
+-- current context state.
+--
+-- Returns @0@ on success or an error code (which can be tested using 'isError').
+-- 
+-- Should be called with one of the reset directive constants:
+-- 
+-- * 'zstd_reset_session_only'
+-- * 'zstd_reset_parameters'
+-- * 'zstd_reset_session_and_parameters'
+foreign import ccall unsafe "ZSTD_CCtx_reset"
+    cCtxReset :: Ptr CCtx -> CInt -> IO CSize

--- a/Codec/Compression/Zstd/FFI/Types.hsc
+++ b/Codec/Compression/Zstd/FFI/Types.hsc
@@ -34,6 +34,16 @@ module Codec.Compression.Zstd.FFI.Types
     , pokeSize
     , peekPos
     , pokePos
+    , zstd_c_compressionLevel
+    , zstd_c_nbWorkers
+    , zstd_c_jobSize
+    , zstd_c_overlapLog
+    , zstd_e_continue
+    , zstd_e_flush
+    , zstd_e_end
+    , zstd_reset_session_only
+    , zstd_reset_parameters
+    , zstd_reset_session_and_parameters
     ) where
 
 #define ZSTD_STATIC_LINKING_ONLY
@@ -111,3 +121,101 @@ peekPos p = (#peek ZSTD_inBuffer, pos) p
 -- | Write to the 'bufPos' value in a 'Buffer'.
 pokePos :: Ptr (Buffer io) -> CSize -> IO ()
 pokePos dst s = (#poke ZSTD_inBuffer, pos) dst s
+
+-- | @ZSTD_c_compressionLevel@ compression parameter, sets the compression
+-- level.
+zstd_c_compressionLevel :: CInt
+zstd_c_compressionLevel = #const ZSTD_c_compressionLevel
+
+-- | @ZSTD_c_nbWorkers@ compression parameter, sets the number of workers.
+--
+-- * @0@: single-threaded (default)
+-- * @N@: multi-threaded mode, using up to @N@ worker threads
+zstd_c_nbWorkers :: CInt
+zstd_c_nbWorkers = #const ZSTD_c_nbWorkers
+
+-- | @ZSTD_c_jobSize@ compression parameter, sets the size of a compression job.
+-- 
+-- @0@ lets zstd pick a default.
+--
+-- /NOTE/: Job size must be a minimum of overlap size, or @ZSTDMT_JOBSIZE_MIN@
+-- (512 KB), whichever is largest.
+--
+-- /NOTE/: Only takes effect when @ZSTD_c_nbWorkers >= 1@.
+zstd_c_jobSize :: CInt
+zstd_c_jobSize = #const ZSTD_c_jobSize
+
+-- | @ZSTD_c_overlapLog@ compression parameter, sets the overlap of consecutive
+-- jobs in multi-threaded mode, as a fraction of window size; larger values
+-- increase compression ratio, but decrease speed.
+--
+-- Range @0..9@:
+--
+-- * @0@ = library default, varies between 6 and 9 depending on compression strategy
+-- * @1@ = no overlap
+-- * @9@ = full window
+--
+-- Each intermediate rank halves the previous overlap:
+--
+-- * @9@: @w@
+-- * @8@: @w\/2@
+-- * @7@: @w\/4@
+--
+-- ...and so on until @1@ (none).
+zstd_c_overlapLog :: CInt
+zstd_c_overlapLog = #const ZSTD_c_overlapLog
+
+-- | @ZSTD_e_continue@ streaming compression parameter, indicates that the
+-- encoder should buffer internally and decide when to return the compressed
+-- result.
+--
+-- Provides better compression at the expense of less regular streaming output.
+--
+-- /NOTE/: When @ZSTD_c_nbWorkers >= 1@, @ZSTD_e_continue@ is non-blocking.
+zstd_e_continue :: CInt
+zstd_e_continue = #const ZSTD_e_continue
+
+-- | @ZSTD_e_flush@ streaming compression parameter, indicates that the encoder
+-- should flush any buffered data to the output and create (at least) one new
+-- block (which can be decoded immediately upon reception).
+--
+-- The frame will continue, and future data can reference previously compressed
+-- data (improving compression).
+--
+-- /NOTE/: Not all data may be flushed in a single call; the encoder must be
+-- invoked repeatedly with this parameter, until it returns @0@.
+-- 
+-- /NOTE/: Multi-threaded compression will block to flush as much output as
+-- possible.
+zstd_e_flush :: CInt
+zstd_e_flush = #const ZSTD_e_flush
+
+-- | @ZSTD_e_end@ streaming compression parameter, indicates that the encoder
+-- should flush any buffered data before closing the frame with an epilogue.
+--
+-- The frame will not continue and any subsequent input starts a new frame,
+-- which cannot reference previously compressed data.
+--
+-- /NOTE/: Not all data may be drained in a single call; the encoder must be
+-- invoked repeatedly with this parameter, until it returns @0@.
+--
+-- /NOTE/: Multi-threaded compression will block to drain as much output as
+-- possible.
+zstd_e_end :: CInt
+zstd_e_end = #const ZSTD_e_end
+
+-- | @ZSTD_reset_session_only@ reset directive, resets session state and
+-- preserves parameter values.
+zstd_reset_session_only :: CInt
+zstd_reset_session_only = #const ZSTD_reset_session_only
+
+-- | @ZSTD_reset_parameters@ reset directive, resets parameter values.
+--
+-- /NOTE/: Only valid before a session begins.
+zstd_reset_parameters :: CInt
+zstd_reset_parameters = #const ZSTD_reset_parameters
+
+-- | @ZSTD_reset_session_and_parameters@ reset directive, resets both session
+-- state and parameter values.
+zstd_reset_session_and_parameters :: CInt
+zstd_reset_session_and_parameters = #const ZSTD_reset_session_and_parameters


### PR DESCRIPTION
## description

doesn't (yet) bind against the full advanced API, just enough to support parallel compression.