### PR TITLE
feat: parallel 'compress' function

### DIFF
--- a/Codec/Compression/Zstd/Advanced.hs
+++ b/Codec/Compression/Zstd/Advanced.hs
@@ -1,0 +1,133 @@
+-- Copyright (c) 2016-present, Facebook, Inc.
+-- All rights reserved.
+--
+-- This source code is licensed under the BSD-style license found in
+-- the LICENSE file in the root directory of this source tree. An
+-- additional grant of patent rights can be found in the PATENTS file
+-- in the same directory.
+
+-- |
+-- Module      : Codec.Compression.Zstd.Advanced
+-- Copyright   : (c) 2016-present, Facebook, Inc. All rights reserved.
+--
+-- License     : BSD3
+-- Maintainer  : luis@luispedro.org
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- Partial coverage for zstd's advanced API.
+--
+-- Meant to be used alongside 'Codec.Compression.Zstd.Efficient' to support
+-- advanced library features, such as parallel compression.
+
+module Codec.Compression.Zstd.Advanced
+    (
+      CParameter(..)
+    , setCParameter
+    , ResetMode(..)
+    , resetCCtx
+    , compress2CCtx
+    , hasMultithreadedSupport
+    ) where
+
+import qualified Codec.Compression.Zstd.FFI as C
+import Codec.Compression.Zstd.Internal
+import Control.Monad (when)
+import Data.ByteString (ByteString)
+import System.IO.Unsafe (unsafePerformIO)
+
+-- | A compression parameter that can be set on a 'CCtx' via
+-- 'setCParameter'.
+--
+-- Parameters are "sticky": once set, they apply to all subsequent
+-- 'compress2CCtx' calls until 'resetCCtx' clears them.
+data CParameter
+    = CompressionLevel Int
+      -- ^ @ZSTD_c_compressionLevel@
+      --
+      -- Default @3@, must be between @1..'C.maxCLevel'@.
+    | NbWorkers Int
+      -- ^ @ZSTD_c_nbWorkers@
+      --
+      -- @0@ disables threading; @>= 1@ runs that many worker threads.
+      --
+      -- /NOTE/: If the linked @libzstd@ was built without support for
+      -- multi-threading support, any non-zero call will fail; call
+      -- 'checkMultithreadedSupport' first if unsure.
+    | JobSize Int
+      -- ^ @ZSTD_c_jobSize@.
+      --
+      -- Size, in bytes, of one compression job in multi-threaded mode.
+      --
+      -- @0@ requests an automatic value.
+    | OverlapLog Int
+      -- ^ @ZSTD_c_overlapLog@.
+      --
+      -- Overlap of consecutive jobs in multi-threaded mode.
+      --
+      -- @0@ = no overlap; @9@ = full window.
+    deriving (Eq, Show)
+
+-- | Set a compression parameter on the context; parameters are sticky
+-- across 'compress2CCtx' calls.
+--
+-- Raises an error if the parameter is invalid for the linked @libzstd@ version.
+setCParameter :: CCtx -> CParameter -> IO ()
+setCParameter (CCtx cc) p = do
+    let (param, value) = encode p
+    rc <- C.cCtxSetParameter cc param (fromIntegral value)
+    when (C.isError rc) $
+      error $ "Codec.Compression.Zstd.Advanced.setCParameter: " ++ C.getErrorName rc
+  where
+    encode (CompressionLevel n) = (C.zstd_c_compressionLevel, n)
+    encode (NbWorkers n)        = (C.zstd_c_nbWorkers,        n)
+    encode (JobSize n)          = (C.zstd_c_jobSize,          n)
+    encode (OverlapLog n)       = (C.zstd_c_overlapLog,       n)
+
+-- | A reset directive, which determines what to clear when calling 'resetCCtx'.
+data ResetMode
+    = ResetSession
+      -- ^ Reset session state (buffered input/output, partial frame).
+    | ResetParameters
+      -- ^ Reset parameters to defaults.
+      --
+      -- /NOTE/: Only valid before a session starts (i.e. before the first
+      -- compress call after a reset).
+    | ResetBoth
+      -- ^ Reset both session state and parameters.
+    deriving (Eq, Show)
+
+-- | Reset a 'CCtx'.
+resetCCtx :: CCtx -> ResetMode -> IO ()
+resetCCtx (CCtx cc) mode = do
+    rc <- C.cCtxReset cc (encode mode)
+    if C.isError rc
+      then error ("Codec.Compression.Zstd.Advanced.resetCCtx: " ++
+                  C.getErrorName rc)
+      else pure ()
+  where
+    encode ResetSession    = C.zstd_reset_session_only
+    encode ResetParameters = C.zstd_reset_parameters
+    encode ResetBoth       = C.zstd_reset_session_and_parameters
+
+-- | Compress using the advanced API: any sticky parameters set via
+-- 'setCParameter' (compression level, worker threads, etc.) are honored.
+--
+-- Always starts a new frame; any partial frame state on the context is
+-- discarded.
+compress2CCtx :: CCtx
+              -- ^ Compression context.
+              -> ByteString
+              -- ^ Payload to compress.
+              -> IO ByteString
+compress2CCtx (CCtx cc) bs =
+    compress2With "compress2CCtx" (C.c_compress2 cc) bs
+
+-- | 'True' if @libzstd@ was compiled with multi-threading
+-- support.
+--
+-- If 'False', any 'NbWorkers' value @>= 1@ passed to 'setCParameter' will fail.
+hasMultithreadedSupport :: Bool
+hasMultithreadedSupport = unsafePerformIO $ withCCtx $ \(CCtx cc) ->
+    not . C.isError <$> C.cCtxSetParameter cc C.zstd_c_nbWorkers 1
+{-# NOINLINE hasMultithreadedSupport #-}

--- a/Codec/Compression/Zstd/FFI.hs
+++ b/Codec/Compression/Zstd/FFI.hs
@@ -106,7 +106,26 @@ module Codec.Compression.Zstd.FFI
     , p_freeDDict
     , decompressUsingDDict
 
+    -- * Advanced API
+    , c_compress2
+    , c_compressStream2
+    , cCtxSetParameter
+    , cCtxReset
+
     -- * Low-level code
+    -- ** Parameter and directive constants
+    , zstd_c_compressionLevel
+    , zstd_c_nbWorkers
+    , zstd_c_jobSize
+    , zstd_c_overlapLog
+    , zstd_e_continue
+    , zstd_e_flush
+    , zstd_e_end
+    , zstd_reset_session_only
+    , zstd_reset_parameters
+    , zstd_reset_session_and_parameters
+
+    -- ** Helper functions
     , c_maxCLevel
     ) where
 
@@ -459,3 +478,71 @@ checkError act = do
   return $! if isError ret
             then Left (getErrorName ret)
             else Right ret
+
+-- | Compress bytes from source buffer into destination buffer using sticky
+-- parameters previously set on the 'CCtx' via 'cCtxSetParameter'.
+--
+-- Always starts a new frame; any previously-buffered partial frame state on
+-- the context is discarded.
+-- 
+-- Returns the number of bytes written into destination buffer, or an error
+-- code if it fails (which can be tested using 'isError').
+--
+-- /NOTE/: 'safe' because this can block when @ZSTD_c_nbWorkers >= 1@.
+foreign import ccall safe "ZSTD_compress2"
+    c_compress2 :: Ptr CCtx     -- ^ Compression context.
+                -> Ptr dst      -- ^ Destination buffer.
+                -> CSize        -- ^ Capacity of destination buffer.
+                -> Ptr src      -- ^ Source buffer.
+                -> CSize        -- ^ Size of source buffer.
+                -> IO CSize
+
+-- | Consume part or all of an input, returning either @0@ (indicating that all
+-- internally buffered data has been flushed and the current operation is
+-- complete) or the minimum number of bytes left to flush.
+-- 
+-- Returns the minimum number of bytes left to flush, @0@ (indicating that all
+-- internally buffered data and the current operation is complete), or an error
+-- code if it fails (which can be tested using 'isError').
+--
+-- The 'CInt' end-directive is one of 'zstd_e_continue' (corresponds to
+-- 'compressStream'), 'zstd_e_flush', or 'zstd_e_end' (corresponds to
+-- 'endStream').
+--
+-- /NOTE/: 'safe' because this can block when @ZSTD_c_nbWorkers >= 1@.
+foreign import ccall safe "ZSTD_compressStream2"
+    c_compressStream2 :: Ptr CCtx          -- ^ Compression context.
+                      -> Ptr (Buffer Out)  -- ^ Output buffer.
+                      -> Ptr (Buffer In)   -- ^ Input buffer.
+                      -> CInt              -- ^ ZSTD_EndDirective.
+                      -> IO CSize
+
+-- | Set a compression parameter on the context.
+--
+-- Parameters are sticky: they apply to every subsequent compression call made
+-- with the given 'CCtx' until reset via 'cCtxReset' with 'zstd_reset_parameters'
+-- or 'zstd_reset_session_and_parameters', or overwritten by another
+-- 'cCtxSetParameter' call.
+-- 
+-- Returns @0@ on success or an error code (which can be tested using 'isError').
+--
+-- /NOTE/: This behavior does __not__ apply to 'compressCCtx', which takes its
+-- compression level inline and does not honor sticky parameters.
+foreign import ccall unsafe "ZSTD_CCtx_setParameter"
+    cCtxSetParameter :: Ptr CCtx
+                     -> CInt   -- ^ ZSTD_cParameter (e.g. 'zstd_c_nbWorkers').
+                     -> CInt   -- ^ Parameter value.
+                     -> IO CSize
+
+-- | Reset the compression context; fails if the directive is invalid for the
+-- current context state.
+--
+-- Returns @0@ on success or an error code (which can be tested using 'isError').
+-- 
+-- Should be called with one of the reset directive constants:
+-- 
+-- * 'zstd_reset_session_only'
+-- * 'zstd_reset_parameters'
+-- * 'zstd_reset_session_and_parameters'
+foreign import ccall unsafe "ZSTD_CCtx_reset"
+    cCtxReset :: Ptr CCtx -> CInt -> IO CSize

--- a/Codec/Compression/Zstd/FFI/Types.hsc
+++ b/Codec/Compression/Zstd/FFI/Types.hsc
@@ -34,6 +34,16 @@ module Codec.Compression.Zstd.FFI.Types
     , pokeSize
     , peekPos
     , pokePos
+    , zstd_c_compressionLevel
+    , zstd_c_nbWorkers
+    , zstd_c_jobSize
+    , zstd_c_overlapLog
+    , zstd_e_continue
+    , zstd_e_flush
+    , zstd_e_end
+    , zstd_reset_session_only
+    , zstd_reset_parameters
+    , zstd_reset_session_and_parameters
     ) where
 
 #define ZSTD_STATIC_LINKING_ONLY
@@ -111,3 +121,101 @@ peekPos p = (#peek ZSTD_inBuffer, pos) p
 -- | Write to the 'bufPos' value in a 'Buffer'.
 pokePos :: Ptr (Buffer io) -> CSize -> IO ()
 pokePos dst s = (#poke ZSTD_inBuffer, pos) dst s
+
+-- | @ZSTD_c_compressionLevel@ compression parameter, sets the compression
+-- level.
+zstd_c_compressionLevel :: CInt
+zstd_c_compressionLevel = #const ZSTD_c_compressionLevel
+
+-- | @ZSTD_c_nbWorkers@ compression parameter, sets the number of workers.
+--
+-- * @0@: single-threaded (default)
+-- * @N@: multi-threaded mode, using up to @N@ worker threads
+zstd_c_nbWorkers :: CInt
+zstd_c_nbWorkers = #const ZSTD_c_nbWorkers
+
+-- | @ZSTD_c_jobSize@ compression parameter, sets the size of a compression job.
+-- 
+-- @0@ lets zstd pick a default.
+--
+-- /NOTE/: Job size must be a minimum of overlap size, or @ZSTDMT_JOBSIZE_MIN@
+-- (512 KB), whichever is largest.
+--
+-- /NOTE/: Only takes effect when @ZSTD_c_nbWorkers >= 1@.
+zstd_c_jobSize :: CInt
+zstd_c_jobSize = #const ZSTD_c_jobSize
+
+-- | @ZSTD_c_overlapLog@ compression parameter, sets the overlap of consecutive
+-- jobs in multi-threaded mode, as a fraction of window size; larger values
+-- increase compression ratio, but decrease speed.
+--
+-- Range @0..9@:
+--
+-- * @0@ = library default, varies between 6 and 9 depending on compression strategy
+-- * @1@ = no overlap
+-- * @9@ = full window
+--
+-- Each intermediate rank halves the previous overlap:
+--
+-- * @9@: @w@
+-- * @8@: @w\/2@
+-- * @7@: @w\/4@
+--
+-- ...and so on until @1@ (none).
+zstd_c_overlapLog :: CInt
+zstd_c_overlapLog = #const ZSTD_c_overlapLog
+
+-- | @ZSTD_e_continue@ streaming compression parameter, indicates that the
+-- encoder should buffer internally and decide when to return the compressed
+-- result.
+--
+-- Provides better compression at the expense of less regular streaming output.
+--
+-- /NOTE/: When @ZSTD_c_nbWorkers >= 1@, @ZSTD_e_continue@ is non-blocking.
+zstd_e_continue :: CInt
+zstd_e_continue = #const ZSTD_e_continue
+
+-- | @ZSTD_e_flush@ streaming compression parameter, indicates that the encoder
+-- should flush any buffered data to the output and create (at least) one new
+-- block (which can be decoded immediately upon reception).
+--
+-- The frame will continue, and future data can reference previously compressed
+-- data (improving compression).
+--
+-- /NOTE/: Not all data may be flushed in a single call; the encoder must be
+-- invoked repeatedly with this parameter, until it returns @0@.
+-- 
+-- /NOTE/: Multi-threaded compression will block to flush as much output as
+-- possible.
+zstd_e_flush :: CInt
+zstd_e_flush = #const ZSTD_e_flush
+
+-- | @ZSTD_e_end@ streaming compression parameter, indicates that the encoder
+-- should flush any buffered data before closing the frame with an epilogue.
+--
+-- The frame will not continue and any subsequent input starts a new frame,
+-- which cannot reference previously compressed data.
+--
+-- /NOTE/: Not all data may be drained in a single call; the encoder must be
+-- invoked repeatedly with this parameter, until it returns @0@.
+--
+-- /NOTE/: Multi-threaded compression will block to drain as much output as
+-- possible.
+zstd_e_end :: CInt
+zstd_e_end = #const ZSTD_e_end
+
+-- | @ZSTD_reset_session_only@ reset directive, resets session state and
+-- preserves parameter values.
+zstd_reset_session_only :: CInt
+zstd_reset_session_only = #const ZSTD_reset_session_only
+
+-- | @ZSTD_reset_parameters@ reset directive, resets parameter values.
+--
+-- /NOTE/: Only valid before a session begins.
+zstd_reset_parameters :: CInt
+zstd_reset_parameters = #const ZSTD_reset_parameters
+
+-- | @ZSTD_reset_session_and_parameters@ reset directive, resets both session
+-- state and parameter values.
+zstd_reset_session_and_parameters :: CInt
+zstd_reset_session_and_parameters = #const ZSTD_reset_session_and_parameters

--- a/Codec/Compression/Zstd/Internal.hs
+++ b/Codec/Compression/Zstd/Internal.hs
@@ -23,6 +23,7 @@ module Codec.Compression.Zstd.Internal
       CCtx(..)
     , DCtx(..)
     , compressWith
+    , compress2With
     , decompressWith
     , decompressedSize
     , withCCtx
@@ -51,16 +52,41 @@ compressWith
     -> Int
     -> ByteString
     -> IO ByteString
-compressWith name compressor level (PS sfp off len)
+compressWith name compressor level bs
   | level < 1 || level > C.maxCLevel
               = bail name "unsupported compression level"
   | otherwise =
+      withCompressBuffers name
+          (\dst dlen src slen ->
+              compressor dst dlen src slen (fromIntegral level))
+          bs
+
+-- | Like 'compressWith' but for the advanced @ZSTD_compress2@ entry point.
+-- 
+-- /NOTE/: Does not accept an argument for compression level, as this must be
+-- ambiently set on the compression context within the compressor closure.
+compress2With
+    :: String
+    -> (Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> IO CSize)
+    -> ByteString
+    -> IO ByteString
+compress2With = withCompressBuffers
+
+-- | Allocate a destination buffer sized via 'C.compressBound' and run
+-- a compressor over the source bytestring.
+--
+-- Shrinks small outputs to avoid retaining the full bound-sized buffer.
+withCompressBuffers :: String
+                    -> (Ptr Word8 -> CSize -> Ptr Word8 -> CSize -> IO CSize)
+                    -> ByteString
+                    -> IO ByteString
+withCompressBuffers name compressor (PS sfp off len) =
   withForeignPtr sfp $ \sp -> do
     maxSize <- C.compressBound (fromIntegral len)
     dfp <- B.mallocByteString (fromIntegral maxSize)
     withForeignPtr dfp $ \dst -> do
       let src = sp `plusPtr` off
-      csz <- compressor dst maxSize src (fromIntegral len) (fromIntegral level)
+      csz <- compressor dst maxSize src (fromIntegral len)
       handleError csz name $ do
         let size = fromIntegral csz
         if csz < 128 || csz >= maxSize `div` 2

--- a/Codec/Compression/Zstd/Parallel.hs
+++ b/Codec/Compression/Zstd/Parallel.hs
@@ -1,0 +1,56 @@
+-- |
+-- Module      : Codec.Compression.Zstd.Parallel
+-- License     : BSD3
+-- Stability   : experimental
+-- Portability : GHC
+--
+-- High-level helpers for compression with multiple worker threads.
+--
+-- For best results, prefer parallel compression for inputs above ~256 KiB
+-- and at compression levels >= 3. For small inputs, the synchronization
+-- overhead of dispatching jobs to worker threads can outweigh any speedup.
+--
+-- /NOTE/: Multi-threading support depends on how the linked @libzstd@ was
+-- built; 'hasMultithreadedSupport' returns 'True' if the runtime library
+-- supports it.
+
+module Codec.Compression.Zstd.Parallel
+    (
+      -- * Basic pure API
+      compress
+    , hasMultithreadedSupport
+    ) where
+
+import Codec.Compression.Zstd.Advanced
+    ( CParameter(..)
+    , compress2CCtx
+    , hasMultithreadedSupport
+    , setCParameter
+    )
+import Codec.Compression.Zstd.Internal (withCCtx)
+import Data.ByteString (ByteString)
+import System.IO.Unsafe (unsafePerformIO)
+
+-- | Compress the given data as a single zstd compressed frame with optional
+-- parallelism.
+--
+-- /NOTE/: Raises an 'error' call if one or more workers was requested, but the
+-- linked @libzstd@ was built without multi-threading support; consult
+-- 'hasMultithreadedSupport' ahead of time to confirm the build configuration.
+--
+-- /NOTE/: Raises an 'error' call if the given compression level is invalid.
+-- 
+-- /NOTE/: Parallelism is handled entirely by @libzstd@, /not/ by GHC's
+-- runtime; workers allocate OS threads, /not/ Haskell's green threads.
+compress :: Int
+         -- ^ Number of worker threads. @0@ disables threading.
+         -> Int
+         -- ^ Compression level. Must be @>= 1@ and @<=
+         -- 'Codec.Compression.Zstd.maxCLevel'@.
+         -> ByteString
+         -- ^ Payload to compress.
+         -> ByteString
+compress workers level bs = unsafePerformIO $ withCCtx $ \ctx -> do
+    setCParameter ctx (CompressionLevel level)
+    setCParameter ctx (NbWorkers workers)
+    compress2CCtx ctx bs

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -17,7 +17,9 @@ module Properties
     ) where
 
 import Codec.Compression.Zstd
+import qualified Codec.Compression.Zstd.Advanced as A
 import qualified Codec.Compression.Zstd.Lazy as L
+import qualified Codec.Compression.Zstd.Parallel as P
 import qualified Codec.Compression.Zstd.Streaming as S
 import Codec.Compression.Zstd.Streaming (Result(..))
 import Data.ByteString (ByteString, pack, unpack)
@@ -60,6 +62,17 @@ t_stream_lazy_compress (CLevel n) = unsquare $ \cs ds s ->
 t_stream_roundtrip (CLevel n) cs s =
   (B.concat . stream S.decompress cs . L.toStrict . L.compress n . L.fromStrict) s == s
 
+t_parallel_roundtrip (CLevel n) (NE s) =
+  forAll (elements supportedWorkerCounts) $ \workers ->
+    decompress (P.compress workers n s) == Decompress s
+  where
+    -- Pick worker counts to exercise; fall back to single-threaded mode if
+    -- @libzstd@ was built without multi-threaded support.
+    supportedWorkerCounts :: [Int]
+    supportedWorkerCounts
+      | A.hasMultithreadedSupport = [0, 1, 2, 4]
+      | otherwise                 = [0]
+
 tests :: Test
 tests = testGroup "properties" [
     testProperty "rechunk" t_rechunk
@@ -69,4 +82,5 @@ tests = testGroup "properties" [
   , testProperty "lazy_compress_equiv" t_lazy_compress_equiv
   , testProperty "stream_lazy_compress" t_stream_lazy_compress
   , testProperty "stream_roundtrip" t_stream_roundtrip
+  , testProperty "parallel_roundtrip" t_parallel_roundtrip
   ]

--- a/zstd.cabal
+++ b/zstd.cabal
@@ -41,6 +41,7 @@ library
     Codec.Compression.Zstd.Base
     Codec.Compression.Zstd.Efficient
     Codec.Compression.Zstd.FFI
+    Codec.Compression.Zstd.Parallel
     Codec.Compression.Zstd.Streaming
     Codec.Compression.Zstd.Types
     Codec.Compression.Zstd

--- a/zstd.cabal
+++ b/zstd.cabal
@@ -37,6 +37,7 @@ flag standalone
 
 library
   exposed-modules:
+    Codec.Compression.Zstd.Advanced
     Codec.Compression.Zstd.Base
     Codec.Compression.Zstd.Efficient
     Codec.Compression.Zstd.FFI


### PR DESCRIPTION
## description

adds a high-level compression function that can dispatch work to OS threads.

depends on #11 & #12

### notes

i have a small, ad-hoc benchmark that measures the speed up from parallelism; not sure if that'd be worth extracting out into a benchmark suite w/ `tasty-bench` or something to show that this actually does what it purports to.